### PR TITLE
Add ci pipeline for project test coverage with jacoco

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run tests and generate JaCoCo report
         run: ./gradlew jacocoTestReport
 
+      - name: Install xmllint
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
       - name: Extract coverage percentage
         id: get_coverage
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,45 @@
+name: Test Coverage
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  test-coverage:
+    name: Run Unit Tests and Enforce 80% Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Grant execution permission for Gradle
+        run: chmod +x ./gradlew
+
+      - name: Run tests and generate JaCoCo report
+        run: ./gradlew jacocoTestReport
+
+      - name: Extract coverage percentage
+        id: get_coverage
+        run: |
+          COVERED=$(xmllint --xpath "string(//report/counter[@type='LINE']/@covered)" app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml)
+          MISSED=$(xmllint --xpath "string(//report/counter[@type='LINE']/@missed)" app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml)
+          TOTAL=$((COVERED + MISSED))
+          PERCENT=$((100 * COVERED / TOTAL))
+          echo "Coverage is $PERCENT%"
+          echo "coverage=$PERCENT" >> $GITHUB_OUTPUT
+
+      - name: Fail if coverage < 80%
+        run: |
+          if [ "${{ steps.get_coverage.outputs.coverage }}" -lt 80 ]; then
+            echo "❌ Test coverage is below 80%!"
+            exit 1
+          else
+            echo "✅ Test coverage meets the requirement."
+          fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    jacoco
 }
 
 android {
@@ -37,6 +38,47 @@ android {
     buildFeatures {
         compose = true
     }
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    dependsOn("testDebugUnitTest")
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+
+    val fileFilter = listOf(
+        "**/R.class",
+        "**/R$*.class",
+        "**/BuildConfig.*",
+        "**/Manifest*.*",
+        "**/*Test*.*",
+        "android/**/*.*"
+    )
+
+    val buildDir = layout.buildDirectory.get().asFile
+
+    val debugTree = fileTree(buildDir.resolve("intermediates/javac/debug")) {
+        exclude(fileFilter)
+    }
+
+    val kotlinDebugTree = fileTree(buildDir.resolve("tmp/kotlin-classes/debug")) {
+        exclude(fileFilter)
+    }
+
+    classDirectories.setFrom(files(debugTree, kotlinDebugTree))
+    sourceDirectories.setFrom(files("src/main/java", "src/main/kotlin"))
+    executionData.setFrom(fileTree(buildDir) {
+        include("jacoco/testDebugUnitTest.exec")
+    })
 }
 
 dependencies {


### PR DESCRIPTION
1. Add Jacoco library for testing
2. Add a CI pipeline verifies the test coverage is 80% or more (the script work in github actions)