### PR TITLE
Refactor: Remove empty search layout from ForYouAndExploreScreen

### DIFF
--- a/presentation/src/main/java/com/madrid/presentation/screens/searchScreen/features/recentSearchLayout/ForYouAndExploreScreen.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/searchScreen/features/recentSearchLayout/ForYouAndExploreScreen.kt
@@ -27,7 +27,6 @@ import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.madrid.designSystem.R
 import com.madrid.designSystem.component.CustomTextTitel
-import com.madrid.designSystem.component.EmptySearchLayout
 import com.madrid.designSystem.component.LoadingSearchCard
 import com.madrid.designSystem.theme.Theme
 import com.madrid.presentation.component.movioCards.MovioVerticalCard
@@ -80,28 +79,6 @@ fun LazyGridScope.forYouAndExploreScreen(
                     }
                 }
             }
-
-            forYouMovies.isEmpty()-> {
-                item(span = { GridItemSpan(maxLineSpan) }) {
-                    Column (
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(top = 64.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
-                    ) {
-                        Image(
-                            painter = painterResource(id =  com.madrid.presentation.R.drawable.img_no_sesrch_found),
-                            contentDescription = "Search Icon",
-                            modifier = Modifier
-                                .size(128.dp)
-                                .align(CenterHorizontally),
-                            contentScale = ContentScale.Fit
-                        )
-                    }
-                }
-            }
-
             forYouMovies.isNotEmpty() -> {
                 item(
                     span = { GridItemSpan(maxLineSpan) }


### PR DESCRIPTION
This commit removes the explicit empty search layout handling within `ForYouAndExploreScreen.kt`. The logic to display an image when `forYouMovies` is empty has been removed. The parent composable or a higher-level component is now expected to handle the empty state. 
**BEFORE**
<img width="383" height="871" alt="image" src="https://github.com/user-attachments/assets/1dc0376a-46d4-44cc-9291-81a6ae4f3abd" />

**AFTER**
<img width="335" height="592" alt="image" src="https://github.com/user-attachments/assets/6e8624e3-bad4-4107-980f-b0011524ffb5" />
