### PR TITLE
Refactor/data store

### DIFF
--- a/app/src/main/java/com/madrid/movio/di/DataModule.kt
+++ b/app/src/main/java/com/madrid/movio/di/DataModule.kt
@@ -1,6 +1,6 @@
 package com.madrid.movio.di
 
-import com.madrid.data.dataSource.encrypted.AuthenticationDatastoreImpl
+import com.madrid.data.dataSource.datastore.AuthenticationDatastoreImpl
 import com.madrid.data.dataSource.local.LocalDataSourceImpl
 import com.madrid.data.dataSource.local.database.MovioDatabase
 import com.madrid.data.repositories.ArtistRepositoryImpl

--- a/app/src/main/java/com/madrid/movio/di/DataModule.kt
+++ b/app/src/main/java/com/madrid/movio/di/DataModule.kt
@@ -1,5 +1,9 @@
 package com.madrid.movio.di
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStoreFile
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import com.madrid.data.dataSource.datastore.UserPreferencesImpl
 import com.madrid.data.dataSource.local.LocalDataSourceImpl
 import com.madrid.data.dataSource.local.database.MovioDatabase
@@ -17,6 +21,7 @@ import com.madrid.domain.repository.MovieRepository
 import com.madrid.domain.repository.SearchRepository
 import com.madrid.domain.repository.SeriesRepository
 import com.madrid.domain.repository.UserRepository
+import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -30,7 +35,12 @@ val dataModule = module {
     single { get<MovioDatabase>().seriesGenreDao() }
     single { get<MovioDatabase>().recentSearchDao() }
     single<LocalDataSource> { LocalDataSourceImpl(get(), get(), get(), get(), get(), get()) }
-    single <UserPreferences>{ UserPreferencesImpl(androidContext()) }
+    single<DataStore<Preferences>> {
+        PreferenceDataStoreFactory.create(
+            produceFile = { androidApplication().dataStoreFile("user_preferences.preferences_pb") }
+        )
+    }
+    single<UserPreferences> { UserPreferencesImpl(get()) }
     single<MovieRepository> { MovieRepositoryImpl(get(), get()) }
     single<SeriesRepository> { SeriesRepositoryImpl(get(), get()) }
     single { GetImageBitmap(get()) }

--- a/app/src/main/java/com/madrid/movio/di/DataModule.kt
+++ b/app/src/main/java/com/madrid/movio/di/DataModule.kt
@@ -1,6 +1,6 @@
 package com.madrid.movio.di
 
-import com.madrid.data.dataSource.datastore.AuthenticationDatastoreImpl
+import com.madrid.data.dataSource.datastore.UserPreferencesImpl
 import com.madrid.data.dataSource.local.LocalDataSourceImpl
 import com.madrid.data.dataSource.local.database.MovioDatabase
 import com.madrid.data.repositories.ArtistRepositoryImpl
@@ -8,7 +8,7 @@ import com.madrid.data.repositories.MovieRepositoryImpl
 import com.madrid.data.repositories.SearchRepositoryImpl
 import com.madrid.data.repositories.SeriesRepositoryImpl
 import com.madrid.data.repositories.UserRepositoryImpl
-import com.madrid.data.repositories.datasource.AuthenticationDataSource
+import com.madrid.data.repositories.datasource.UserPreferences
 import com.madrid.data.repositories.local.LocalDataSource
 import com.madrid.detectImageContent.GetImageBitmap
 import com.madrid.detectImageContent.SensitiveContentDetection
@@ -30,7 +30,7 @@ val dataModule = module {
     single { get<MovioDatabase>().seriesGenreDao() }
     single { get<MovioDatabase>().recentSearchDao() }
     single<LocalDataSource> { LocalDataSourceImpl(get(), get(), get(), get(), get(), get()) }
-    single <AuthenticationDataSource>{ AuthenticationDatastoreImpl(androidContext()) }
+    single <UserPreferences>{ UserPreferencesImpl(androidContext()) }
     single<MovieRepository> { MovieRepositoryImpl(get(), get()) }
     single<SeriesRepository> { SeriesRepositoryImpl(get(), get()) }
     single { GetImageBitmap(get()) }

--- a/data/src/main/java/com/madrid/data/dataSource/datastore/AuthenticationDatastore.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/datastore/AuthenticationDatastore.kt
@@ -1,4 +1,4 @@
-package com.madrid.data.dataSource.encrypted
+package com.madrid.data.dataSource.datastore
 
 import android.content.Context
 import androidx.datastore.core.DataStore

--- a/data/src/main/java/com/madrid/data/dataSource/datastore/AuthenticationDatastore.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/datastore/AuthenticationDatastore.kt
@@ -6,13 +6,13 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.madrid.data.repositories.datasource.AuthenticationDataSource
+import com.madrid.data.repositories.datasource.UserPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class AuthenticationDatastoreImpl(
+class UserPreferencesImpl(
     private val context: Context
-) : AuthenticationDataSource {
+) : UserPreferences {
     val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings") //TODO: Move to secrets
 
     val TOKEN = stringPreferencesKey("token") //TODO: Move to secrets

--- a/data/src/main/java/com/madrid/data/dataSource/datastore/Crypto.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/datastore/Crypto.kt
@@ -1,4 +1,4 @@
-package com.madrid.data.dataSource.encrypted
+package com.madrid.data.dataSource.datastore
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties

--- a/data/src/main/java/com/madrid/data/dataSource/datastore/UserData.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/datastore/UserData.kt
@@ -1,4 +1,4 @@
-package com.madrid.data.dataSource.encrypted
+package com.madrid.data.dataSource.datastore
 
 import androidx.datastore.core.Serializer
 import kotlinx.coroutines.Dispatchers

--- a/data/src/main/java/com/madrid/data/dataSource/datastore/UserPreferencesImpl.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/datastore/UserPreferencesImpl.kt
@@ -1,45 +1,44 @@
 package com.madrid.data.dataSource.datastore
 
-import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.madrid.data.repositories.datasource.UserPreferences
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class UserPreferencesImpl(
-    private val context: Context
+    private val dataStore: DataStore<Preferences>
 ) : UserPreferences {
-    val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings") //TODO: Move to secrets
-
-    val TOKEN = stringPreferencesKey("token") //TODO: Move to secrets
 
     override fun getAuthToken(): Flow<String> {
-        return context.dataStore.data
+        return dataStore.data
             .map { preferences ->
                 preferences[TOKEN] ?: ""
             }
     }
 
     override fun isUserLoggedIn(): Flow<Boolean> {
-        return context.dataStore.data
+        return dataStore.data
             .map { preferences ->
                 preferences[TOKEN]?.isNotEmpty() ?: false
             }
     }
 
     override suspend fun setAuthToken(token: String) {
-        context.dataStore.edit { settings ->
+        dataStore.edit { settings ->
             settings[TOKEN] = token
         }
     }
 
     override suspend fun clearAuthToken() {
-        context.dataStore.edit { settings ->
+        dataStore.edit { settings ->
             settings[TOKEN] = ""
         }
+    }
+
+    companion object {
+        val TOKEN = stringPreferencesKey("token") //TODO: Move to secrets
     }
 }

--- a/data/src/main/java/com/madrid/data/repositories/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/madrid/data/repositories/UserRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.madrid.data.repositories
 
-import com.madrid.data.repositories.datasource.AuthenticationDataSource
+import com.madrid.data.repositories.datasource.UserPreferences
 import com.madrid.data.repositories.local.LocalDataSource
 import com.madrid.data.repositories.remote.RemoteDataSource
 import com.madrid.domain.entity.User
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 class UserRepositoryImpl(
     private val remoteDataSource: RemoteDataSource,
     private val localDataSource: LocalDataSource,
-    private val authenticationDatasource: AuthenticationDataSource
+    private val authenticationDatasource: UserPreferences
 ) : UserRepository {
 
     override suspend fun login(

--- a/data/src/main/java/com/madrid/data/repositories/datasource/UserPreferences.kt
+++ b/data/src/main/java/com/madrid/data/repositories/datasource/UserPreferences.kt
@@ -2,7 +2,7 @@ package com.madrid.data.repositories.datasource
 
 import kotlinx.coroutines.flow.Flow
 
-interface AuthenticationDataSource {
+interface UserPreferences {
     fun getAuthToken(): Flow<String>
     fun isUserLoggedIn(): Flow<Boolean>
     suspend fun setAuthToken(token: String)


### PR DESCRIPTION
This PR refactors the datastore by:
- Rename `AuthenticationDataSource` to `UserPreferences` for better clarity
- Remove direct Context dependency from the DataStore implementation
- Inject DataStore through Koin
- Update DI module to provide DataStore instance