### PR TITLE
Feature/episode trailer

### DIFF
--- a/data/src/main/java/com/madrid/data/dataSource/remote/MovioApi.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/remote/MovioApi.kt
@@ -1,27 +1,36 @@
 package com.madrid.data.dataSource.remote
 
-import com.madrid.data.dataSource.remote.dto.common.AddToFavoriteRequest
 import com.madrid.data.dataSource.remote.dto.artist.ArtistDetailsResponse
 import com.madrid.data.dataSource.remote.dto.artist.ArtistKnownForResponse
 import com.madrid.data.dataSource.remote.dto.artist.SearchArtistResponse
 import com.madrid.data.dataSource.remote.dto.authentication.AccountDetailsResponse
 import com.madrid.data.dataSource.remote.dto.authentication.AuthenticationResponse
 import com.madrid.data.dataSource.remote.dto.authentication.CreateSessionBody
+import com.madrid.data.dataSource.remote.dto.authentication.CreateSessionRawBody
+import com.madrid.data.dataSource.remote.dto.authentication.SessionIdResponse
+import com.madrid.data.dataSource.remote.dto.common.AddToFavoriteRequest
 import com.madrid.data.dataSource.remote.dto.common.TrailerResponse
 import com.madrid.data.dataSource.remote.dto.genre.GenresResponse
+import com.madrid.data.dataSource.remote.dto.list.AddToListRequest
+import com.madrid.data.dataSource.remote.dto.list.CreateListResponse
+import com.madrid.data.dataSource.remote.dto.list.ListOperationResponse
+import com.madrid.data.dataSource.remote.dto.list.ListsDetailsResponse
+import com.madrid.data.dataSource.remote.dto.list.ListsResponse
+import com.madrid.data.dataSource.remote.dto.list.MovieListBody
+import com.madrid.data.dataSource.remote.dto.movie.ListDetailsResponse
 import com.madrid.data.dataSource.remote.dto.movie.MovieCreditsResponse
 import com.madrid.data.dataSource.remote.dto.movie.MovieDetailsResponse
 import com.madrid.data.dataSource.remote.dto.movie.MovieReviewResponse
 import com.madrid.data.dataSource.remote.dto.movie.NowPlayingMovieResponse
 import com.madrid.data.dataSource.remote.dto.movie.SearchMovieResponse
 import com.madrid.data.dataSource.remote.dto.movie.SimilarMoviesResponse
-import com.madrid.data.dataSource.remote.dto.rating.RateRequest
-import com.madrid.data.dataSource.remote.dto.series.RecommendedSeriesResponse
 import com.madrid.data.dataSource.remote.dto.movie.UpcomingMoviesResponse
 import com.madrid.data.dataSource.remote.dto.rate.RatingMovieResponse
 import com.madrid.data.dataSource.remote.dto.rate.RatingSeriesResponse
+import com.madrid.data.dataSource.remote.dto.rating.RateRequest
 import com.madrid.data.dataSource.remote.dto.series.AiringTodayTvShowsResponse
 import com.madrid.data.dataSource.remote.dto.series.OnAirTvShowsResponse
+import com.madrid.data.dataSource.remote.dto.series.RecommendedSeriesResponse
 import com.madrid.data.dataSource.remote.dto.series.SearchSeriesResponse
 import com.madrid.data.dataSource.remote.dto.series.SeasonResponse
 import com.madrid.data.dataSource.remote.dto.series.SeriesCreditResponse
@@ -29,15 +38,6 @@ import com.madrid.data.dataSource.remote.dto.series.SeriesDetailsResponse
 import com.madrid.data.dataSource.remote.dto.series.SeriesReviewResponse
 import com.madrid.data.dataSource.remote.dto.series.SimilarSeriesResponse
 import com.madrid.data.dataSource.remote.dto.series.TopRatedSeriesResponse
-import com.madrid.data.dataSource.remote.dto.authentication.CreateSessionRawBody
-import com.madrid.data.dataSource.remote.dto.authentication.SessionIdResponse
-import com.madrid.data.dataSource.remote.dto.list.AddToListRequest
-import com.madrid.data.dataSource.remote.dto.list.CreateListResponse
-import com.madrid.data.dataSource.remote.dto.list.ListOperationResponse
-import com.madrid.data.dataSource.remote.dto.list.MovieListBody
-import com.madrid.data.dataSource.remote.dto.movie.ListDetailsResponse
-import com.madrid.data.dataSource.remote.dto.list.ListsDetailsResponse
-import com.madrid.data.dataSource.remote.dto.list.ListsResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -180,6 +180,13 @@ interface MovioApi {
         @Query(WITH_GENRES) genreId: Int?,
         @Query(SORT_BY) sortBy: String
     ): SearchSeriesResponse
+
+    @GET("tv/{series_id}/season/{season_number}/episode/{episode_number}/videos")
+    suspend fun getEpisodeTrailers(
+        @Path("series_id") seriesId: Int,
+        @Path("season_number") seasonNumber: Int,
+        @Path("episode_number") episodeNumber: Int
+    ): TrailerResponse
     // endregion
 
 

--- a/data/src/main/java/com/madrid/data/dataSource/remote/RemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/madrid/data/dataSource/remote/RemoteDataSourceImpl.kt
@@ -159,6 +159,16 @@ class RemoteDataSourceImpl @Inject constructor(
         return api.getFavoriteSeries(sessionId).seriesResults
     }
 
+    override suspend fun getEpisodeTrailers(
+        episodeNumber: Int,
+        seasonNumber: Int,
+        seriesId: Int
+    ): List<TrailerResult> {
+        return api.getEpisodeTrailers(seriesId, seasonNumber, episodeNumber).results
+    }
+
+
+
     // Artist
     override suspend fun searchArtistByQuery(name: String, page: Int): SearchArtistResponse {
         return api.searchArtistByQuery(name, page)

--- a/data/src/main/java/com/madrid/data/repositories/SeriesRepositoryImpl.kt
+++ b/data/src/main/java/com/madrid/data/repositories/SeriesRepositoryImpl.kt
@@ -120,6 +120,15 @@ class SeriesRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun getEpisodeTrailers(
+        seriesId: Int,
+        seasonNumber: Int,
+        episodeNumber: Int
+    ): List<Trailer> {
+        return remoteDataSource.getEpisodeTrailers(episodeNumber, seasonNumber, seriesId)
+            .map { it.toTrailer() }
+    }
+
     override suspend fun getSeriesByGenres(): Map<String, List<Series>> {
         val genresWithSeries = localDataSource.getSeriesByGenres()
         return genresWithSeries.associate { genreWithSeries ->

--- a/data/src/main/java/com/madrid/data/repositories/remote/RemoteDataSource.kt
+++ b/data/src/main/java/com/madrid/data/repositories/remote/RemoteDataSource.kt
@@ -7,30 +7,30 @@ import com.madrid.data.dataSource.remote.dto.authentication.AccountDetailsRespon
 import com.madrid.data.dataSource.remote.dto.common.TrailerResult
 import com.madrid.data.dataSource.remote.dto.genre.RemoteGenreDto
 import com.madrid.data.dataSource.remote.dto.list.CreateListResponse
-import com.madrid.data.dataSource.remote.dto.list.ListOperationResponse
-import com.madrid.data.dataSource.remote.dto.list.MovieListBody
 import com.madrid.data.dataSource.remote.dto.list.ListDto
+import com.madrid.data.dataSource.remote.dto.list.ListOperationResponse
 import com.madrid.data.dataSource.remote.dto.list.ListsDetailsResponse
+import com.madrid.data.dataSource.remote.dto.list.MovieListBody
 import com.madrid.data.dataSource.remote.dto.movie.MovieCreditsResponse
 import com.madrid.data.dataSource.remote.dto.movie.MovieDetailsResponse
 import com.madrid.data.dataSource.remote.dto.movie.MovieResult
 import com.madrid.data.dataSource.remote.dto.movie.MovieReviewResponse
+import com.madrid.data.dataSource.remote.dto.movie.NowPlayingMovieResponse
 import com.madrid.data.dataSource.remote.dto.movie.SearchMovieResponse
 import com.madrid.data.dataSource.remote.dto.movie.SimilarMoviesResponse
+import com.madrid.data.dataSource.remote.dto.movie.UpcomingMoviesResponse
 import com.madrid.data.dataSource.remote.dto.rate.RatingMovieResponse
 import com.madrid.data.dataSource.remote.dto.rate.RatingSeriesResponse
+import com.madrid.data.dataSource.remote.dto.series.AiringTodayTvShowsResponse
+import com.madrid.data.dataSource.remote.dto.series.OnAirTvShowsResponse
+import com.madrid.data.dataSource.remote.dto.series.RecommendedSeriesResponse
 import com.madrid.data.dataSource.remote.dto.series.SearchSeriesResponse
 import com.madrid.data.dataSource.remote.dto.series.SeasonResponse
 import com.madrid.data.dataSource.remote.dto.series.SeriesCreditResponse
 import com.madrid.data.dataSource.remote.dto.series.SeriesDetailsResponse
+import com.madrid.data.dataSource.remote.dto.series.SeriesResult
 import com.madrid.data.dataSource.remote.dto.series.SeriesReviewResponse
 import com.madrid.data.dataSource.remote.dto.series.SimilarSeriesResponse
-import com.madrid.data.dataSource.remote.dto.movie.NowPlayingMovieResponse
-import com.madrid.data.dataSource.remote.dto.movie.UpcomingMoviesResponse
-import com.madrid.data.dataSource.remote.dto.series.AiringTodayTvShowsResponse
-import com.madrid.data.dataSource.remote.dto.series.OnAirTvShowsResponse
-import com.madrid.data.dataSource.remote.dto.series.RecommendedSeriesResponse
-import com.madrid.data.dataSource.remote.dto.series.SeriesResult
 import com.madrid.data.dataSource.remote.dto.series.TopRatedSeriesResponse
 
 interface RemoteDataSource {
@@ -72,6 +72,11 @@ interface RemoteDataSource {
     suspend fun getRecommendedSeries(page: Int = 1): RecommendedSeriesResponse
     suspend fun getSeriesByGenreId(page: Int, genreId: Int?, sortBy: String): SearchSeriesResponse
     suspend fun getFavoriteSeries(sessionId: String): List<SeriesResult>
+    suspend fun getEpisodeTrailers(
+        episodeNumber: Int,
+        seasonNumber: Int,
+        seriesId: Int
+    ): List<TrailerResult>
     // endregion
 
     // region Artist

--- a/domain/src/main/java/com/madrid/domain/entity/Episode.kt
+++ b/domain/src/main/java/com/madrid/domain/entity/Episode.kt
@@ -7,4 +7,5 @@ data class Episode(
     val duration: String,
     val imageUrl : String,
     val rate : Double,
+    val trailer: Trailer? = null
 )

--- a/domain/src/main/java/com/madrid/domain/repository/SeriesRepository.kt
+++ b/domain/src/main/java/com/madrid/domain/repository/SeriesRepository.kt
@@ -30,4 +30,9 @@ interface SeriesRepository {
     suspend fun getAllSeriesInHistory(): List<Series>
     suspend fun getFavoriteSeries(sessionId: String): List<Series>
     suspend fun setSeriesFavoriteStatus(seriesId: Int, sessionId: String, isFavorite: Boolean)
+    suspend fun getEpisodeTrailers(
+        seriesId: Int,
+        seasonNumber: Int,
+        episodeNumber: Int
+    ): List<Trailer>
 }

--- a/domain/src/main/java/com/madrid/domain/usecase/series/GetEpisodeTrailersUseCase.kt
+++ b/domain/src/main/java/com/madrid/domain/usecase/series/GetEpisodeTrailersUseCase.kt
@@ -1,0 +1,22 @@
+package com.madrid.domain.usecase.series
+
+import com.madrid.domain.entity.Trailer
+import com.madrid.domain.repository.SeriesRepository
+import javax.inject.Inject
+
+class GetEpisodeTrailersUseCase @Inject constructor(
+    private val seriesRepository: SeriesRepository
+) {
+    suspend operator fun invoke(
+        seriesId: Int,
+        seasonNumber: Int,
+        episodeNumber: Int
+    ): List<Trailer> {
+        return try {
+            seriesRepository.getEpisodeTrailers(seriesId, seasonNumber, episodeNumber)
+        } catch (e: Exception) {
+            println("Error fetching episode trailer: $e")
+            emptyList()
+        }
+    }
+}

--- a/presentation/src/main/java/com/madrid/presentation/screens/detailsScreen/seriesDetails/EpisodesScreen.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/detailsScreen/seriesDetails/EpisodesScreen.kt
@@ -1,5 +1,6 @@
 package com.madrid.presentation.screens.detailsScreen.seriesDetails
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -16,7 +17,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.madrid.designSystem.component.MovioText
 import com.madrid.designSystem.component.TopAppBar
@@ -33,16 +36,34 @@ import com.madrid.presentation.viewModel.detailsViewModel.SeriesDetailsViewModel
 fun EpisodesScreen(viewModel: SeriesDetailsViewModel = hiltViewModel()) {
     val uiState by viewModel.state.collectAsState()
     val navController = LocalNavController.current
+    val context = LocalContext.current
     EpisodesScreenContent(
-        uiState,
-        viewModel::updateSelectedSeason,
-        onClickBack = { navController.popBackStack() })
+        uiState = uiState,
+        onSeasonSelection = viewModel::updateSelectedSeason,
+        onClickEpisode = { episode ->
+            viewModel.loadEpisodeTrailer(
+                seriesId = uiState.seriesId,
+                seasonNumber = uiState.selectedSeasonUiState.seasonNumber,
+                episodeNumber = episode.episodeNumber
+            ) { trailerKey ->
+                trailerKey?.let {
+                    val intent = Intent(
+                        Intent.ACTION_VIEW,
+                        "https://www.youtube.com/watch?v=$it".toUri()
+                    )
+                    context.startActivity(intent)
+                }
+            }
+        },
+        onClickBack = { navController.popBackStack() }
+    )
 }
 
 @Composable
 fun EpisodesScreenContent(
     uiState: SeriesDetailsUiState,
     onSeasonSelection: (Int) -> Unit = {},
+    onClickEpisode: (EpisodeUiState) -> Unit = {},
     onClickBack: () -> Unit = {},
 ) {
     val episodes: List<EpisodeUiState> = uiState.selectedSeasonUiState.episodesUiStates
@@ -99,14 +120,12 @@ fun EpisodesScreenContent(
                 currentMovieEpisode = episode.episodeNumber.toString(),
                 movieTime = "${episode.episodeDuration} m",
                 movieImageUrl = episode.imageUrl,
-                onClick = {
-                },
+                onClick = { onClickEpisode(episode) },
                 modifier = Modifier.padding(bottom = 12.dp, start = 16.dp, end = 16.dp)
             )
         }
     }
 }
-
 
 private fun getSeasonsNames(numberOfSeasons: Int, uiState: SeriesDetailsUiState): List<String> {
     return if (uiState.currentSeasonsUiStates.first().seasonNumber == 0)

--- a/presentation/src/main/java/com/madrid/presentation/screens/detailsScreen/seriesDetails/SeriesDetailsScreen.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/detailsScreen/seriesDetails/SeriesDetailsScreen.kt
@@ -52,8 +52,6 @@ import com.madrid.designSystem.component.EmptySearchLayout
 import com.madrid.designSystem.component.MovioBottomSheet
 import com.madrid.designSystem.component.MovioIcon
 import com.madrid.designSystem.component.MovioText
-import com.madrid.designSystem.component.TextWithReadMore
-import com.madrid.designSystem.component.MovioBottomSheet
 import com.madrid.designSystem.component.ShareBottomSheetContent
 import com.madrid.designSystem.component.TextWithReadMore
 import com.madrid.designSystem.component.TopAppBar
@@ -170,7 +168,7 @@ fun SeriesDetailsScreen(
                     .offset(y = 342.dp)
                     .background(
                         Brush.verticalGradient(
-                            colors = listOf(Color.Transparent , Theme.color.surfaces.surface)
+                            colors = listOf(Color.Transparent, Theme.color.surfaces.surface)
                         )
                     )
             )
@@ -286,7 +284,7 @@ fun SeriesDetailsScreen(
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth(),
-                                horizontalAlignment = Alignment.CenterHorizontally
+                                horizontalAlignment = CenterHorizontally
                             ) {
                                 MovioArtistsCard(
                                     imageUrl = uiState.topImageUrl,
@@ -369,7 +367,9 @@ fun SeriesDetailsScreen(
                                     .padding(bottom = 16.dp)
                             )
                             Row(
-                                modifier = Modifier.padding(top = 16.dp).align(Alignment.CenterHorizontally),
+                                modifier = Modifier
+                                    .padding(top = 16.dp)
+                                    .align(CenterHorizontally),
                                 horizontalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
                                 (1..5).forEach { i ->
@@ -450,7 +450,7 @@ fun SeriesDetailsScreen(
                 CustomTextTitle(
                     primaryText = stringResource(R.string.current_seasons),
                     secondaryText = stringResource(R.string.see_all),
-                    endIcon = painterResource(com.madrid.designSystem.R.drawable.outline_alt_arrow_left),
+                    endIcon = painterResource(drawable.outline_alt_arrow_left),
                     onSeeAllClick = {
                         navController.navigate(
                             Destinations.SeasonsScreen(

--- a/presentation/src/main/java/com/madrid/presentation/viewModel/detailsViewModel/SeriesDetailsMappers.kt
+++ b/presentation/src/main/java/com/madrid/presentation/viewModel/detailsViewModel/SeriesDetailsMappers.kt
@@ -11,6 +11,7 @@ fun Episode.toUiState(): EpisodeUiState {
         episodeNumber = this.episodeNumber,
         episodeDuration = this.duration,
         rate = this.rate.toString(),
+        trailerKey = this.trailer.toString(),
     )
 }
 

--- a/presentation/src/main/java/com/madrid/presentation/viewModel/detailsViewModel/SeriesDetailsUiState.kt
+++ b/presentation/src/main/java/com/madrid/presentation/viewModel/detailsViewModel/SeriesDetailsUiState.kt
@@ -54,4 +54,5 @@ data class EpisodeUiState(
     val episodeNumber: Int = 0,
     val episodeDuration: String = "",
     val rate: String = "",
+    val trailerKey: String?
 )

--- a/presentation/src/main/java/com/madrid/presentation/viewModel/detailsViewModel/SeriesDetailsViewModel.kt
+++ b/presentation/src/main/java/com/madrid/presentation/viewModel/detailsViewModel/SeriesDetailsViewModel.kt
@@ -8,8 +8,8 @@ import com.madrid.domain.entity.Review
 import com.madrid.domain.entity.Series
 import com.madrid.domain.usecase.authentication.LoginUseCase
 import com.madrid.domain.usecase.series.AddRatingSeriesUseCase
-import com.madrid.domain.usecase.series.SetSeriesFavoriteStatusUseCase
 import com.madrid.domain.usecase.series.AddSeriesToHistoryUseCase
+import com.madrid.domain.usecase.series.GetEpisodeTrailersUseCase
 import com.madrid.domain.usecase.series.GetEpisodesForSeasonUseCase
 import com.madrid.domain.usecase.series.GetSeriesDetailsUseCase
 import com.madrid.domain.usecase.series.GetSeriesReviewsUseCase
@@ -17,6 +17,7 @@ import com.madrid.domain.usecase.series.GetSeriesTopCastUseCase
 import com.madrid.domain.usecase.series.GetSeriesTrailersUseCase
 import com.madrid.domain.usecase.series.GetSimilarSeriesUseCase
 import com.madrid.domain.usecase.series.IsFavoriteSeriesUseCase
+import com.madrid.domain.usecase.series.SetSeriesFavoriteStatusUseCase
 import com.madrid.presentation.navigation.Destinations
 import com.madrid.presentation.utils.RateFormatter
 import com.madrid.presentation.viewModel.base.BaseViewModel
@@ -42,7 +43,8 @@ class SeriesDetailsViewModel @Inject constructor(
     private val isGuestUseCase: LoginUseCase,
     private val getSeriesTrailersUseCase: GetSeriesTrailersUseCase,
     private val setSeriesFavoriteStatusUseCase: SetSeriesFavoriteStatusUseCase,
-    private val isFavoriteSeriesUseCase: IsFavoriteSeriesUseCase
+    private val isFavoriteSeriesUseCase: IsFavoriteSeriesUseCase,
+    private val getEpisodeTrailersUseCase: GetEpisodeTrailersUseCase,
 ) : BaseViewModel<SeriesDetailsUiState, Nothing>(SeriesDetailsUiState()) {
     private val args = savedStateHandle.toRoute<Destinations.SeriesDetailsScreen>()
 
@@ -72,6 +74,24 @@ class SeriesDetailsViewModel @Inject constructor(
             },
             onError = { error ->
                 Log.d("SeriesTrailer", "Failed to load trailer: ${error.message}")
+            }
+        )
+    }
+
+    fun loadEpisodeTrailer(
+        seriesId: Int,
+        seasonNumber: Int,
+        episodeNumber: Int,
+        onTrailerLoaded: (String?) -> Unit
+    ) {
+        tryToExecute(
+            function = { getEpisodeTrailersUseCase(seriesId, seasonNumber, episodeNumber) },
+            onSuccess = { trailers ->
+                val trailerKey = trailers.firstOrNull()?.key
+                onTrailerLoaded(trailerKey)
+            },
+            onError = {
+                onTrailerLoaded(null)
             }
         )
     }


### PR DESCRIPTION
This pull request adds support for fetching and displaying trailers for individual TV show episodes within the series details flow. The changes span the data, domain, and presentation layers, introducing a new use case and updating the UI to allow users to view episode trailers directly from the episodes list.

**Key changes include:**

### Data Layer Enhancements
- Added the `getEpisodeTrailers` endpoint to the `MovioApi` interface and implemented it in `RemoteDataSourceImpl`, allowing retrieval of trailers for specific episodes. [[1]](diffhunk://#diff-3c75f5e90777f285029a0e245a997233bb6c94d0613971d21ddc4caae3fd93a3R183-R189) [[2]](diffhunk://#diff-b48fae9d8de91630a6518324518227c4a65d3789a91e7bd26ca5568baf5f9574R162-R171)
- Updated the `RemoteDataSource` interface to expose the new `getEpisodeTrailers` method.

### Domain Layer Additions
- Introduced the `GetEpisodeTrailersUseCase` to encapsulate the logic for fetching episode trailers via the repository.
- Extended the `SeriesRepository` interface and its implementation to support fetching episode trailers, mapping the results to domain entities. [[1]](diffhunk://#diff-52ce63eb10c56ff5e6ea7ac8411cf46618ad52968cd8f54aec7148cf24c587abR33-R37) [[2]](diffhunk://#diff-3d8659ddbd428fd702d09e663964c6029db0b818ae8c3009c47272015740d573R123-R131)
- Updated the `Episode` entity to optionally include a `Trailer` property.

### Presentation Layer & UI Updates
- Modified the `EpisodesScreen` and its content to handle episode clicks, triggering trailer loading and launching the YouTube trailer in an external browser if available. [[1]](diffhunk://#diff-6b530556be89a6b4da1b21b5f1a92bb872d7507f919c73dd3b130894e7a2b1adR39-R66) [[2]](diffhunk://#diff-6b530556be89a6b4da1b21b5f1a92bb872d7507f919c73dd3b130894e7a2b1adL102-L110)
- Updated the `EpisodeUiState` and its mapping to include the trailer key, allowing the UI to access the trailer information. [[1]](diffhunk://#diff-23ed956f812ceafc143bd9bfc7a9f69ae921fa943828bf0e0e7294a23c7cc33eR57) [[2]](diffhunk://#diff-1bbbb908f4b0a4b405d8be2cb426cec8484a9437f15d1e31d6aadb6342871156R14)
- Injected the new `GetEpisodeTrailersUseCase` into `SeriesDetailsViewModel` and wired up the logic to fetch and provide trailer keys for episodes. [[1]](diffhunk://#diff-6460be319017f14d477b343f61467a59f6c764e33cf97403054ac9540627fcfdL11-R20) [[2]](diffhunk://#diff-6460be319017f14d477b343f61467a59f6c764e33cf97403054ac9540627fcfdL45-R47)

### Minor Improvements & Cleanup
- Fixed and reorganized imports across several files for clarity and to remove redundancies. [[1]](diffhunk://#diff-3c75f5e90777f285029a0e245a997233bb6c94d0613971d21ddc4caae3fd93a3L3-L40) [[2]](diffhunk://#diff-225077eeeec971d5be5099ab19ee843f617ad0150bdd484b037a0f9dfe8bf8c6L10-L33) [[3]](diffhunk://#diff-19d74f89771ff92b79116ec3d3396239a07055ccb9fd9aac184656c4cd253711L55-L56)
- Minor UI alignment and resource reference fixes in `SeriesDetailsScreen`. [[1]](diffhunk://#diff-19d74f89771ff92b79116ec3d3396239a07055ccb9fd9aac184656c4cd253711L289-R287) [[2]](diffhunk://#diff-19d74f89771ff92b79116ec3d3396239a07055ccb9fd9aac184656c4cd253711L372-R372) [[3]](diffhunk://#diff-19d74f89771ff92b79116ec3d3396239a07055ccb9fd9aac184656c4cd253711L453-R453)

These changes collectively enable users to view trailers for specific TV show episodes directly from the app, improving the series details experience.

https://github.com/user-attachments/assets/93e7c002-e376-4590-9226-fcfc2e25a58c

