### PR TITLE
fix: Restore navigation bars padding in MovioNavGraph

### DIFF
--- a/presentation/src/main/java/com/madrid/presentation/navigation/MovioNavGraph.kt
+++ b/presentation/src/main/java/com/madrid/presentation/navigation/MovioNavGraph.kt
@@ -41,10 +41,10 @@ fun MovioNavGraph(
     Column(
         Modifier
             .fillMaxSize()
-            .navigationBarsPadding()
             .background(
                 color = Theme.color.surfaces.surface
             )
+            .navigationBarsPadding()
     ) {
         Column(
             modifier = Modifier
@@ -81,3 +81,4 @@ fun MovioNavGraph(
         }
     }
 }
+


### PR DESCRIPTION

<table>
<tr>
 <td>before
 <td>after
<tr>
 <td><img width="1178" height="2498" alt="image" src="https://github.com/user-attachments/assets/20d295e6-5b53-4f60-bb89-24e1d311eb17" />

 <td><img width="1178" height="2498" alt="image" src="https://github.com/user-attachments/assets/e7f607a3-05ed-49d6-9a02-4faf966d8268" />

</table>