### PR TITLE
fix: MovieLoginContent padding

### DIFF
--- a/presentation/src/main/java/com/madrid/presentation/screens/loginScreen/component/MovieLoginContent.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/loginScreen/component/MovieLoginContent.kt
@@ -52,7 +52,7 @@ fun MovieLoginContent(
                 onUsernameChange = interactionListener::onUsernameChanged,
                 onPasswordChange = interactionListener::onPasswordChanged,
                 onTogglePassword = interactionListener::onShowPasswordToggled,
-                modifier = Modifier.padding(bottom = screenHeight * 0.03f)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
             LoginErrorAndForgotPassword(


### PR DESCRIPTION

This pull request makes a minor UI adjustment in the `MovieLoginContent` composable. The bottom padding for the login form is changed from a percentage of the screen height to a fixed value for more consistent spacing across devices.

* Changed the `modifier` for padding in the login form from `Modifier.padding(bottom = screenHeight * 0.03f)` to `Modifier.padding(bottom = 8.dp)` in `MovieLoginContent`.<table style="width: 100%; border-collapse: collapse;"><tbody><tr><th style="width: 50%; text-align: center; border: 1px solid #ccc; padding: 8px;">Before</th><th style="width: 50%; text-align: center; border: 1px solid #ccc; padding: 8px;">After</th></tr><tr><td style="width: 50%; text-align: center; border: 1px solid #ccc; padding: 8px;"><img style="max-width: 100%; height: auto;" alt="Before" src="https://github.com/user-attachments/assets/fe03adb0-46e0-41d7-a7a9-875ce4fb8164"></td><td style="width: 50%; text-align: center; border: 1px solid #ccc; padding: 8px;"><img style="max-width: 100%; height: auto;" alt="After" src="https://github.com/user-attachments/assets/3f4d7a86-21fb-4104-bee4-6b6be4fd08e1"></td></tr></tbody></table>