### PR TITLE
fix: loading data when navigate back to library screen

### DIFF
--- a/presentation/src/main/java/com/madrid/presentation/screens/libraryScreen/LibraryScreen.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/libraryScreen/LibraryScreen.kt
@@ -44,6 +44,10 @@ fun LibraryScreen(
     val state = libraryViewModel.state.collectAsStateWithLifecycle().value
     val navController = LocalNavController.current
 
+    LaunchedEffect(Unit) {
+        libraryViewModel.loadData()
+    }
+
     LaunchedEffect(libraryViewModel.effect) {
         libraryViewModel.effect.collectLatest { effect ->
             when (effect) {

--- a/presentation/src/main/java/com/madrid/presentation/screens/libraryScreen/ViewAllScreen.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/libraryScreen/ViewAllScreen.kt
@@ -46,9 +46,7 @@ fun ViewAllScreen(
         viewModel.effect.collect { effect ->
             when (effect) {
                 is ViewAllEffect.NavigateBack -> {
-                    navController.navigate(
-                        Destinations.LibraryScreen
-                    )
+                    navController.navigateUp()
                 }
 
                 is ViewAllEffect.NavigateToDetails -> {

--- a/presentation/src/main/java/com/madrid/presentation/screens/libraryScreen/WatchlistViewAllScreen.kt
+++ b/presentation/src/main/java/com/madrid/presentation/screens/libraryScreen/WatchlistViewAllScreen.kt
@@ -53,9 +53,7 @@ fun WatchlistViewAllScreen(
         viewModel.effect.collect { effect ->
             when (effect) {
                 is WatchlistViewAllEffect.NavigateBack -> {
-                    navController.navigate(
-                        Destinations.LibraryScreen
-                    )
+                    navController.navigateUp()
                 }
 
                 is WatchlistViewAllEffect.NavigateToDetails -> {

--- a/presentation/src/main/java/com/madrid/presentation/viewModel/libraryViewModel/LibraryViewModel.kt
+++ b/presentation/src/main/java/com/madrid/presentation/viewModel/libraryViewModel/LibraryViewModel.kt
@@ -1,5 +1,6 @@
 package com.madrid.presentation.viewModel.libraryViewModel
 
+import android.util.Log
 import com.madrid.domain.usecase.authentication.LoginUseCase
 import com.madrid.domain.usecase.movie.CreateMovieListUseCase
 import com.madrid.domain.usecase.movie.GetAllMoviesInHistoryUseCase
@@ -23,7 +24,7 @@ class LibraryViewModel @Inject constructor(
     LibraryScreenState()
 ), LibraryInteractionListener {
 
-    init {
+    fun loadData(){
         getWatchList()
         getFavoriteList()
         getHistoryList()


### PR DESCRIPTION
Done: when navigate to details from library screen , and then go back , the library screen reloads data